### PR TITLE
fix: added pnpm install to release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,22 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version: 'lts/*'
-      - run: pnpm install
-      - run: pnpm run release
+          version: 9
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      
+      - name: Run release
+        run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
Quick change to add the pnpm install step in the ci.yml file; previously it was only present for the test job, not the release job.